### PR TITLE
Fix predict_tgl_kmeans on large inputs (#21)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tglkmeans
 Title: Efficient Implementation of K-Means++ Algorithm
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: c(
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),
     person("Amos", "Tanay", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tglkmeans 0.6.2
+
+* Fix: `predict_tgl_kmeans()` crashed with `'from' contains NAs` / `NAs introduced by coercion to integer range` on inputs of ~46K rows or more. The one-shot `as.matrix(tgs_dist(.))` overflowed integer indexing inside `stats:::as.matrix.dist`. The prediction now processes observations in chunks (#21).
+
 # tglkmeans 0.6.1
 
 * Added `predict_tgl_kmeans()` function to assign new observations to existing k-means cluster centers (#5).

--- a/R/TGL_kmeans.R
+++ b/R/TGL_kmeans.R
@@ -488,21 +488,41 @@ predict_tgl_kmeans <- function(object, newdata, id_column = FALSE, ...) {
     n_obs <- nrow(mat)
     n_centers <- nrow(center_mat)
 
-    if (metric == "euclid") {
-        # Combine observations and centers, compute full distance matrix, extract subblock
-        combined <- rbind(mat, center_mat)
-        dist_mat <- as.matrix(tgs_dist(combined))
-        # Rows 1:n_obs vs columns (n_obs+1):(n_obs+n_centers)
-        obs_center_dists <- dist_mat[seq_len(n_obs), n_obs + seq_len(n_centers), drop = FALSE]
-    } else {
-        # For pearson/spearman: columns are variables in tgs_cor, so transpose and combine
-        combined <- cbind(t(mat), t(center_mat))
-        cor_mat <- tgs_cor(combined,
-            pairwise.complete.obs = TRUE,
-            spearman = (metric == "spearman")
-        )
-        # Extract n_obs x n_centers subblock and negate (distance = -correlation)
-        obs_center_dists <- -cor_mat[seq_len(n_obs), n_obs + seq_len(n_centers), drop = FALSE]
+    # Process observations in chunks. The previous one-shot approach built a
+    # full (n_obs + n_centers)^2 distance/correlation matrix; for n_obs above
+    # ~46340, length(df) in stats:::as.matrix.dist overflows integer range and
+    # the call dies with "NAs introduced by coercion to integer range" (issue
+    # #21). Chunking also bounds peak memory.
+    chunk_size <- 10000L
+    obs_center_dists <- matrix(NA_real_, n_obs, n_centers)
+
+    if (n_obs > 0L) {
+        for (start in seq.int(1L, n_obs, by = chunk_size)) {
+            end <- min(start + chunk_size - 1L, n_obs)
+            chunk <- mat[start:end, , drop = FALSE]
+            n_chunk <- nrow(chunk)
+
+            if (metric == "euclid") {
+                combined <- rbind(chunk, center_mat)
+                dist_mat <- as.matrix(tgs_dist(combined))
+                obs_center_dists[start:end, ] <- dist_mat[
+                    seq_len(n_chunk),
+                    n_chunk + seq_len(n_centers),
+                    drop = FALSE
+                ]
+            } else {
+                combined <- cbind(t(chunk), t(center_mat))
+                cor_mat <- tgs_cor(combined,
+                    pairwise.complete.obs = TRUE,
+                    spearman = (metric == "spearman")
+                )
+                obs_center_dists[start:end, ] <- -cor_mat[
+                    seq_len(n_chunk),
+                    n_chunk + seq_len(n_centers),
+                    drop = FALSE
+                ]
+            }
+        }
     }
 
     assigned_clusts <- center_clusts[apply(obs_center_dists, 1, which.min)]

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -333,3 +333,59 @@ test_that("TGL_kmeans also auto-detects character first column", {
     # Names should be the sample_id values
     expect_equal(names(res$cluster), data$sample_id)
 })
+
+# predict_tgl_kmeans:
+test_that("predict_tgl_kmeans recovers training cluster assignments (euclid)", {
+    data <- simulate_data(n = 200, sd = 0.3, dims = 5, nclust = 5, frac_na = NULL)
+    res <- TGL_kmeans_tidy(data %>% select(id, starts_with("V")),
+        k = 5, id_column = TRUE, metric = "euclid", verbose = FALSE, seed = 60427
+    )
+    pred <- predict_tgl_kmeans(res, data %>% select(starts_with("V")))
+    expect_equal(nrow(pred), nrow(data))
+    expect_setequal(colnames(pred), c("id", "clust"))
+    expect_true(all(pred$clust %in% res$centers$clust))
+    expect_equal(pred$clust, res$cluster$clust)
+})
+
+test_that("predict_tgl_kmeans pearson/spearman round-trip", {
+    data <- simulate_data(n = 200, sd = 0.3, dims = 10, nclust = 5, frac_na = NULL)
+    for (m in c("pearson", "spearman")) {
+        res <- TGL_kmeans_tidy(data %>% select(id, starts_with("V")),
+            k = 5, id_column = TRUE, metric = m, verbose = FALSE, seed = 60427
+        )
+        pred <- predict_tgl_kmeans(res, data %>% select(starts_with("V")))
+        expect_equal(nrow(pred), nrow(data))
+        expect_true(all(pred$clust %in% res$centers$clust))
+    }
+})
+
+# Issue #21: as.matrix(tgs_dist(.)) in predict overflowed integer range once
+# the combined size exceeded ~46340 rows. Verify large inputs no longer crash
+# and that chunked results agree with a brute-force per-center computation
+# on a tractable subset.
+test_that("predict_tgl_kmeans handles input larger than as.matrix.dist int limit (#21)", {
+    skip_on_cran()
+    set.seed(60427)
+    nclust <- 5
+    train <- simulate_data(n = 200, sd = 0.3, dims = 4, nclust = nclust, frac_na = NULL)
+    res <- TGL_kmeans_tidy(train %>% select(id, starts_with("V")),
+        k = nclust, id_column = TRUE, metric = "euclid", verbose = FALSE, seed = 60427
+    )
+
+    # Trigger the old code path: combined size = 50000 + nclust > 46340.
+    big <- matrix(rnorm(50000 * 4), nrow = 50000, ncol = 4)
+    colnames(big) <- paste0("V", seq_len(4))
+    expect_no_error(pred <- predict_tgl_kmeans(res, big))
+    expect_equal(nrow(pred), nrow(big))
+    expect_true(all(pred$clust %in% res$centers$clust))
+
+    # Cross-check chunked result against a brute-force per-row nearest-center
+    # assignment on a small subset (tgs_dist's NA-aware Euclidean reduces to
+    # the plain Euclidean when no NAs are present).
+    subset <- big[1:500, , drop = FALSE]
+    centers <- as.matrix(res$centers[, -1])
+    brute <- apply(subset, 1, function(x) {
+        which.min(sqrt(rowSums(sweep(centers, 2, x, "-")^2)))
+    })
+    expect_equal(pred$clust[1:500], res$centers$clust[brute])
+})


### PR DESCRIPTION
## Summary
- Root cause: `predict_tgl_kmeans()` built a full `(n_obs + n_centers)^2` distance / correlation matrix and sliced an `n_obs x n_centers` sub-block. For `n_obs + n_centers > 46340`, `length(df) = size^2` in `stats:::as.matrix.dist` overflows `.Machine$integer.max` and the call dies with `'from' contains NAs` / `NAs introduced by coercion to integer range`.
- Fix: process the observations in 10K-row chunks, computing per-chunk `tgs_dist` / `tgs_cor` and filling a pre-allocated `n_obs x n_centers` matrix. Per-pair semantics are unchanged; peak intermediate memory is also bounded.
- Adds three `predict_tgl_kmeans` tests: round-trip euclid, round-trip pearson/spearman, and a 50K-row regression test for #21 cross-checked against a brute-force per-row nearest-center assignment.

Fixes #21.

## Test plan
- [x] R CMD INSTALL clean
- [x] Full test suite (NOT_CRAN=true): 294 PASS / 0 FAIL / 0 WARN / 0 SKIP
- [x] End-to-end repro: predict on 100K rows completes in ~14s without error
- [ ] CI green