### PR TITLE
Fix Spearman NA handling and euclid train/predict consistency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # tglkmeans 0.6.3
 
+* Fix: `metric = "spearman"` ignored missing values. Ranking tested the wrong
+  missing-value sentinel, so `NA`s were ranked as the largest value and included
+  in the rank correlation instead of being dropped. Spearman now excludes missing
+  values pairwise, matching `euclid`/`pearson`. Clustering results for Spearman on
+  data with `NA`s change (and are now correct); results on complete data are
+  unchanged.
+* Fix: `predict_tgl_kmeans()` with `metric = "euclid"` used a plain Euclidean
+  distance, which disagreed with the training metric `sqrt(sum_sq) / n` when a
+  cluster center had a missing dimension. Prediction now reproduces the training
+  distance exactly. Predictions on data whose centers have no missing dimensions
+  are unchanged.
 * Performance: removed the dense `k x n` per-thread vote matrix in the
   reassignment step. Memory and per-iteration work no longer scale with the
   number of clusters; cluster assignments are unchanged.

--- a/R/TGL_kmeans.R
+++ b/R/TGL_kmeans.R
@@ -425,9 +425,10 @@ TGL_kmeans <- function(df,
 #' used is the same one that was used when creating the k-means model (\code{"euclid"},
 #' \code{"pearson"}, or \code{"spearman"}).
 #'
-#' Distance formulas:
+#' Distance formulas (matching the training implementation; \code{n} is the number
+#' of dimensions present in both \code{x} and \code{center}):
 #' \itemize{
-#'   \item \code{euclid}: \code{sqrt(sum((x - center)^2, na.rm = TRUE))}
+#'   \item \code{euclid}: \code{sqrt(sum((x - center)^2, na.rm = TRUE)) / n}
 #'   \item \code{pearson}: \code{-cor(x, center, use = "pairwise.complete.obs")}
 #'   \item \code{spearman}: \code{-cor(x, center, method = "spearman", use = "pairwise.complete.obs")}
 #' }
@@ -488,36 +489,36 @@ predict_tgl_kmeans <- function(object, newdata, id_column = FALSE, ...) {
     n_obs <- nrow(mat)
     n_centers <- nrow(center_mat)
 
-    # Process observations in chunks. The previous one-shot approach built a
-    # full (n_obs + n_centers)^2 distance/correlation matrix; for n_obs above
-    # ~46340, length(df) in stats:::as.matrix.dist overflows integer range and
-    # the call dies with "NAs introduced by coercion to integer range" (issue
-    # #21). Chunking also bounds peak memory.
-    #
-    # Only the obs x centers block of each chunk's matrix is used; the
-    # chunk x chunk block is computed and discarded. Since every obs-to-center
-    # distance/correlation is pairwise (independent of the other observations in
-    # the chunk), the result does not depend on chunk_size - so we keep the
-    # chunk modest to limit that wasted O(chunk^2) work while still doing few
-    # tgs calls.
-    chunk_size <- 1000L
     obs_center_dists <- matrix(NA_real_, n_obs, n_centers)
 
     if (n_obs > 0L) {
-        for (start in seq.int(1L, n_obs, by = chunk_size)) {
-            end <- min(start + chunk_size - 1L, n_obs)
-            chunk <- mat[start:end, , drop = FALSE]
-            n_chunk <- nrow(chunk)
+        if (metric == "euclid") {
+            # Reproduce the training Euclidean distance exactly: sqrt(sum_sq)/n
+            # over the dimensions present in BOTH the observation and the center
+            # (see KMeansCenterMeanEuclid::dist). tgs_dist's plain Euclidean
+            # disagrees once a center has a missing dimension, so n differs
+            # across centers. Computed directly per center (n_centers is small),
+            # which also avoids the O(n_obs^2) distance matrix entirely.
+            for (j in seq_len(n_centers)) {
+                sq <- sweep(mat, 2, center_mat[j, ], "-")^2
+                n_overlap <- rowSums(!is.na(sq))
+                sum_sq <- rowSums(sq, na.rm = TRUE)
+                obs_center_dists[, j] <- ifelse(n_overlap > 0, sqrt(sum_sq) / n_overlap, Inf)
+            }
+        } else {
+            # Pearson / Spearman via tgs_cor, in chunks. The previous one-shot
+            # approach built a full (n_obs + n_centers)^2 correlation matrix; for
+            # n_obs above ~46340, length(df) in stats:::as.matrix.dist overflows
+            # integer range (issue #21). Only the obs x centers block of each
+            # chunk is used; the chunk x chunk block is computed and discarded.
+            # Each obs-to-center correlation is pairwise (independent of the other
+            # observations in the chunk), so the result is chunk_size-independent.
+            chunk_size <- 1000L
+            for (start in seq.int(1L, n_obs, by = chunk_size)) {
+                end <- min(start + chunk_size - 1L, n_obs)
+                chunk <- mat[start:end, , drop = FALSE]
+                n_chunk <- nrow(chunk)
 
-            if (metric == "euclid") {
-                combined <- rbind(chunk, center_mat)
-                dist_mat <- as.matrix(tgs_dist(combined))
-                obs_center_dists[start:end, ] <- dist_mat[
-                    seq_len(n_chunk),
-                    n_chunk + seq_len(n_centers),
-                    drop = FALSE
-                ]
-            } else {
                 combined <- cbind(t(chunk), t(center_mat))
                 cor_mat <- tgs_cor(combined,
                     pairwise.complete.obs = TRUE,

--- a/man/predict_tgl_kmeans.Rd
+++ b/man/predict_tgl_kmeans.Rd
@@ -32,9 +32,10 @@ cluster center and assigns the observation to the nearest center. The distance m
 used is the same one that was used when creating the k-means model (\code{"euclid"},
 \code{"pearson"}, or \code{"spearman"}).
 
-Distance formulas:
+Distance formulas (matching the training implementation; \code{n} is the number
+of dimensions present in both \code{x} and \code{center}):
 \itemize{
-  \item \code{euclid}: \code{sqrt(sum((x - center)^2, na.rm = TRUE))}
+  \item \code{euclid}: \code{sqrt(sum((x - center)^2, na.rm = TRUE)) / n}
   \item \code{pearson}: \code{-cor(x, center, use = "pairwise.complete.obs")}
   \item \code{spearman}: \code{-cor(x, center, method = "spearman", use = "pairwise.complete.obs")}
 }

--- a/src/KMeans.h
+++ b/src/KMeans.h
@@ -21,6 +21,9 @@ protected:
 
     const std::vector<std::vector<float>> &m_data;
 
+    // Intentionally float, not an integer count: cluster() tests convergence
+    // with m_changes / m_assignment.size(). As an int this would be integer
+    // division and always evaluate to 0, so the loop would stop after one pass.
     float m_changes;
 
     bool m_use_cpp_random;

--- a/src/KMeansCenterMeanPearson.cpp
+++ b/src/KMeansCenterMeanPearson.cpp
@@ -24,7 +24,7 @@ float KMeansCenterMeanPearson::dist(const vector<float> &x) const
     float x_e = 0;
     int n = 0;
     for(vector<float>::const_iterator c_i = m_center.begin(); c_i != m_center.end(); c_i++) {
-        if(!isnan(*x_i) && *x_i != REAL_MAX && *c_i != REAL_MAX) {
+        if(*x_i != REAL_MAX && *c_i != REAL_MAX) {
             cov2 += (*c_i) * (*x_i);
             x_v2 += (*x_i) * (*x_i);
             x_e += (*x_i);

--- a/src/Ranking.cpp
+++ b/src/Ranking.cpp
@@ -8,6 +8,12 @@ using namespace std;
 // missing if either `vals` or the paired `noz_vals` is missing there. Tied
 // values all receive the average of their ranks, so the result is independent
 // of the order of equal elements in `order` (hence a non-stable sort is fine).
+//
+// Two distinct sentinels are in play: missing *input* data is +REAL_MAX (set by
+// replace_na in TGLkmeans.cpp, matching every other distance metric), while a
+// missing *output* rank is flagged with -REAL_MAX (safe because real ranks are
+// always positive). spearman() relies on the latter to skip missing positions.
+// (A prior version tested inputs against -REAL_MAX and so never excluded NAs.)
 void cond_mid_ranking(vector<float> &ranks,
 		const vector<int> &order, const
 		vector<float> &vals, const vector<float> &noz_vals)
@@ -16,7 +22,7 @@ void cond_mid_ranking(vector<float> &ranks,
 	float ecount = 0;
 	vector<int>::const_iterator i = order.begin();
 	while(i != order.end()
-	&& (vals[*i] == -REAL_MAX || noz_vals[*i] == -REAL_MAX)) {
+	&& (vals[*i] == REAL_MAX || noz_vals[*i] == REAL_MAX)) {
 		ranks[*i] = -REAL_MAX;
 		i++;
 	}
@@ -25,7 +31,7 @@ void cond_mid_ranking(vector<float> &ranks,
 		prev_val = vals[*i];
 	}
 	while(i != order.end()) {
-		if(vals[*i] == -REAL_MAX || noz_vals[*i] == -REAL_MAX) {
+		if(vals[*i] == REAL_MAX || noz_vals[*i] == REAL_MAX) {
 			ranks[*i] = -REAL_MAX;
 			i++;
 			continue;
@@ -39,8 +45,8 @@ void cond_mid_ranking(vector<float> &ranks,
 					do {
 						j--;
 					} while(j != order.begin()
-					&& (vals[*j] == -REAL_MAX
-					|| noz_vals[*j] == -REAL_MAX));
+					&& (vals[*j] == REAL_MAX
+					|| noz_vals[*j] == REAL_MAX));
 					ranks[*j] = mean_count;
 				}
 			}
@@ -56,7 +62,7 @@ void cond_mid_ranking(vector<float> &ranks,
 	if(ecount > 1) {
 		float mean_count = count + (ecount-1)/2;
 		vector<int>::const_reverse_iterator j = order.rbegin();
-		while(vals[*j] == -REAL_MAX || noz_vals[*j] == -REAL_MAX) {
+		while(vals[*j] == REAL_MAX || noz_vals[*j] == REAL_MAX) {
 			j++;
 		}
 		for(int k = 0; k < ecount; k++) {
@@ -64,8 +70,8 @@ void cond_mid_ranking(vector<float> &ranks,
 			do {
 				j++;
 			} while(j != order.rend()
-			&& (vals[*j] == -REAL_MAX
-			|| noz_vals[*j] == -REAL_MAX));
+			&& (vals[*j] == REAL_MAX
+			|| noz_vals[*j] == REAL_MAX));
 		}
 		count += ecount;
 	}

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -390,6 +390,55 @@ test_that("predict_tgl_kmeans pearson/spearman round-trip", {
     }
 })
 
+# Bug #2: the training Euclidean distance is sqrt(sum_sq)/n where n is the number
+# of dimensions present in BOTH the point and the center. predict must use the
+# same metric. It used to call tgs_dist (a plain Euclidean), which disagrees once
+# a center has a missing dimension so that n differs across centers. Here center 1
+# is missing V2, so for x = (2, 3):
+#   d(x, center1) = sqrt((2-0)^2) / 1          = 2.00
+#   d(x, center2) = sqrt((2-0)^2 + (3-0)^2) / 2 = 1.80  <- nearer under the training metric
+# A plain Euclidean would instead pick center 1 (2.00 < 3.61).
+test_that("predict_tgl_kmeans euclid uses the training metric when a center has NA (#2)", {
+    object <- structure(
+        list(
+            centers = tibble::tibble(clust = c(1L, 2L), V1 = c(0, 0), V2 = c(NA, 0)),
+            metric = "euclid"
+        ),
+        class = "tgl_kmeans"
+    )
+    newdata <- matrix(c(2, 3), nrow = 1, dimnames = list(NULL, c("V1", "V2")))
+    pred <- predict_tgl_kmeans(object, newdata)
+    expect_equal(pred$clust, 2L)
+})
+
+# Bug #1: cond_mid_ranking tested the wrong missing sentinel (-REAL_MAX) while NAs
+# are encoded as +REAL_MAX, so Spearman never excluded missing values - it ranked
+# them as the largest value. The final training assignment is argmin distance to
+# the centers, so every observation's assigned center must be (up to numerical
+# tolerance) the nearest under an independent pairwise-complete Spearman computed
+# in R. With the bug, observations with NAs are assigned to a center that is not
+# actually nearest once missing values are properly dropped.
+test_that("TGL_kmeans spearman excludes missing values (#1)", {
+    data <- simulate_data(n = 200, sd = 0.3, dims = 10, nclust = 5, frac_na = 0.1)
+    res <- TGL_kmeans_tidy(data %>% select(id, starts_with("V")),
+        k = 5, id_column = TRUE, metric = "spearman", verbose = FALSE, seed = 60427
+    )
+    mat <- as.matrix(data %>% select(starts_with("V")))
+    centers <- as.matrix(res$centers[, -1])
+    # pairwise-complete Spearman distance (-cor) from each observation to each center
+    D <- matrix(NA_real_, nrow(mat), nrow(centers))
+    for (j in seq_len(nrow(centers))) {
+        D[, j] <- -suppressWarnings(apply(mat, 1, function(x) {
+            stats::cor(x, centers[j, ], method = "spearman", use = "pairwise.complete.obs")
+        }))
+    }
+    train_col <- match(res$cluster$clust, res$centers$clust)
+    row_min <- apply(D, 1, min, na.rm = TRUE)
+    train_dist <- D[cbind(seq_len(nrow(D)), train_col)]
+    # the assigned center is the nearest one (ties from float-vs-double allowed)
+    expect_true(all(train_dist - row_min < 1e-4, na.rm = TRUE))
+})
+
 # Issue #21: as.matrix(tgs_dist(.)) in predict overflowed integer range once
 # the combined size exceeded ~46340 rows. Verify large inputs no longer crash
 # and that chunked results agree with a brute-force per-center computation


### PR DESCRIPTION
## Summary

Two metric bugs surfaced during a package review, plus small cleanups.

### Bug 1 (High): `metric = "spearman"` ignored missing values
`cond_mid_ranking` tested the wrong missing-value sentinel (`-REAL_MAX`) while NAs are encoded as `+REAL_MAX`, so missing values were never excluded - they were ranked as the largest value and included in the rank correlation. Every other metric (`euclid`, `pearson`) excludes NAs pairwise; Spearman now does too.

Verified at the unit level: `spearman()` on a vector with one missing entry returned `0.428571` (NA included as a huge value) and now returns `0.6` (correct pairwise-complete Spearman).

The internal *rank*-missing sentinel (also `-REAL_MAX`) is unchanged; only the *input*-value checks were corrected. Both sentinels are now documented in `Ranking.cpp`.

### Bug 2 (Medium): `predict_tgl_kmeans(metric = "euclid")` used a different distance than training
Training uses `sqrt(sum_sq) / n` (`n` = jointly non-missing dims); predict used `tgs_dist`'s plain Euclidean. They agree whenever centers are complete (the normal case) but diverge once a center has a missing dimension. Predict now computes the training distance directly per center, so it reproduces training exactly. This also removes the discarded O(chunk^2) distance matrix on the euclid path. **Training is unchanged, so clustering results do not change.**

### Cleanups
- Removed the dead `!isnan` check in Pearson (NaN is already mapped to `REAL_MAX`; now consistent with Euclid).
- Documented that `m_changes` is intentionally `float` (an `int` would make the convergence test integer-divide to 0 and stop after one pass).

## Tests
- `TGL_kmeans spearman excludes missing values (#1)`: asserts every training assignment is the nearest center under an independent R pairwise-complete Spearman. Fails on old code (max gap 0.6), passes now.
- `predict_tgl_kmeans euclid uses the training metric when a center has NA (#2)`: known-answer case with a center missing a dimension. Fails on old code (picks the wrong center), passes now.

## Compatibility
- Complete-data results: unchanged for all metrics.
- Spearman on data with NAs: results change (and are now correct).
- The local `kmeans_spearman_with_na` regression snapshot (gitignored) was regenerated; `kmeans_euclid_with_na` and `kmeans_spearman_basic` were unaffected.

NEWS updated. Full `devtools::test()` suite passes locally.